### PR TITLE
feat(tests): add tests folder with router.test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ on:
     branches: ["*"]
 
 jobs:
-  test:
+  tests:
     runs-on: ubuntu-latest
     steps:
       - name: Setup repo
@@ -19,3 +19,5 @@ jobs:
         run: deno fmt --check
       - name: Types check
         run: deno check .
+      - name: Testing
+        run: deno test tests/

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -1,0 +1,66 @@
+import { assertEquals } from "jsr:@std/assert";
+import { Router } from "../router.ts";
+import { createFakeRequest } from "./utils.ts";
+
+Deno.test("Router should handle GET requests", async () => {
+  const router = new Router();
+
+  router.get("/hello", () => new Response("Hello world"));
+
+  const request = createFakeRequest("http://localhost/hello", "GET");
+  const response = await router.handler(request);
+
+  assertEquals(await response.text(), "Hello world");
+  assertEquals(response.status, 200);
+});
+
+Deno.test("Router should handle POST requests", async () => {
+  const router = new Router();
+
+  router.post("/hello", async (request) => {
+    const body = await request.json();
+    return new Response(JSON.stringify(body), {
+      headers: { "Content-Type": "application/json" },
+    });
+  });
+
+  const request = createFakeRequest(
+    "http://localhost/hello",
+    "POST",
+    {},
+    { message: "Hello world" }
+  );
+  const response = await router.handler(request);
+
+  assertEquals(await response.json(), { message: "Hello world" });
+  assertEquals(response.status, 200);
+});
+
+Deno.test("Router should execute middleware", async () => {
+  const router = new Router();
+
+  let middlewareExecuted = false;
+  router.use((_, next) => {
+    middlewareExecuted = true;
+    return next();
+  });
+
+  router.get("/hello", () => new Response("Hello world"));
+
+  const request = createFakeRequest("http://localhost/hello", "GET");
+  const response = await router.handler(request);
+
+  assertEquals(middlewareExecuted, true);
+  assertEquals(await response.text(), "Hello world");
+  assertEquals(response.status, 200);
+});
+
+Deno.test("Router should return 404 for unknown routes", async () => {
+  const router = new Router();
+
+  const request = createFakeRequest("http://localhost/unknown", "GET");
+  const response = await router.handler(request);
+
+  assertEquals(response.status, 404);
+  assertEquals(await response.text(), "Not found");
+});

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,0 +1,26 @@
+/**
+ * Creates a fake Request object for testing purposes.
+ * @param {string} url - The URL of the request.
+ * @param {string} method - The HTTP method of the request.
+ * @param {Record<string, string>} [headers] - Optional headers for the request.
+ * @param {any} [body] - Optional body for the request.
+ * @returns {Request} - The fake Request object.
+ */
+export function createFakeRequest(
+  url: string,
+  method: string,
+  headers: Record<string, string> = {},
+  body: unknown = null
+): Request {
+  const init: RequestInit = {
+    method,
+    headers: new Headers(headers),
+  };
+
+  if (body) {
+    init.body = JSON.stringify(body);
+    (init.headers as Headers).set("Content-Type", "application/json");
+  }
+
+  return new Request(url, init);
+}


### PR DESCRIPTION
This pull request includes changes to the testing workflow and the addition of new tests for the router.

Updates to the testing workflow:

* [`.github/workflows/tests.yml`](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL9-R9): Renamed from `test.yml`, changed the job name from `test` to `tests`, and added a new step to run tests using `deno test tests/`. [[1]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL9-R9) [[2]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fR22-R23)

Addition of new tests:

* [`tests/router.test.ts`](diffhunk://#diff-56c92063910ea376ca11a7f6c8f093e3a4a58b7635a6fdb53ec7912c5f5be269R1-R66): Added multiple tests to verify the router's handling of GET and POST requests, middleware execution, and 404 responses for unknown routes.
* [`tests/utils.ts`](diffhunk://#diff-bccd87d19079cf7b35274281848f7e5a32a070e5101bff9c5b67b58fb82fc16dR1-R26): Added a utility function `createFakeRequest` to create fake `Request` objects for testing purposes.