### PR TITLE
Release: 0.3.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ on:
     branches: ["*"]
 
 jobs:
-  test:
+  tests:
     runs-on: ubuntu-latest
     steps:
       - name: Setup repo
@@ -19,3 +19,5 @@ jobs:
         run: deno fmt --check
       - name: Types check
         run: deno check .
+      - name: Testing
+        run: deno test tests/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,6 @@ jobs:
       - name: Fmt check
         run: deno fmt --check
       - name: Types check
-        run: deno check .
+        run: deno check router.ts types.ts utils/
       - name: Testing
-        run: deno test tests/
+        run: deno test .

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 docs/
+coverage/

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Here's an example of how to use the Router class with deno serve :
 ```ts
 // server.ts
 import { Router } from '@decelerate/cruiseh';
+import { getUrlParams } from "@decelerate/cruiseh/utils/getUrlParams";
 
 const app = new Router();
 
@@ -54,9 +55,14 @@ app.post("/hello", async (req) => {
 
 // With params
 app.get("/hello/:id", (_req, matchedRoute) => {
-  const routePattern = matchedRoute.exec(req.url)
-  const id = routePattern?.pathname.groups.id;
-  const body = { id };
+  // If you don't want to use utils function you can do the same thing manually
+  //const routePattern = matchedRoute.exec(req.url);
+  //const params = routePattern?.pathname.groups;
+
+  // For more secure way, you may need to try/catch your operations
+  const params = getUrlParams<{ id: string }>(matchedRoute, req.url);
+
+  const body = { id: params.id };
 
   return new Response(JSON.stringify(body), {
     status: 200,

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cruiseh
 [![jsr.io/@decelerate/cruiseh](https://jsr.io/badges/@decelerate/cruiseh)](https://jsr.io/@decelerate/cruiseh)
 [![jsr.io/@decelerate/cruiseh score](https://jsr.io/badges/@decelerate/cruiseh/score)](https://jsr.io/@decelerate/cruiseh)
-[![cruiseh ci](https://github.com/decelerate/cruiseh/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/decelerate/cruiseh)
+[![cruiseh ci](https://github.com/decelerate/cruiseh/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/decelerate/cruiseh)
 
 > [!CAUTION]
 > Only work with deno runtime for the moment

--- a/deno.json
+++ b/deno.json
@@ -15,16 +15,12 @@
       "deno.json",
       "index.ts",
       "router.ts",
-      "types.ts"
+      "types.ts",
+      "utils.ts"
     ]
   },
   "tasks": {
-    "doc:gen": "deno doc --html --name=\"Cruiseh API\" ./index.ts",
-    "doc:dev": "deno run -A docs-dev-server.ts",
-    "doc:lint": "deno doc --lint index.ts",
-    "fmt": "deno fmt",
-    "fmt:check": "deno fmt --check",
-    "check": "deno check ."
+    "check": "deno check router.ts types.ts utils/"
   },
   "fmt": {
     "exclude": [

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@decelerate/cruiseh",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "MIT",
   "exports": {
     ".": "./index.ts",

--- a/examples/deno-basic/deno.json
+++ b/examples/deno-basic/deno.json
@@ -3,6 +3,6 @@
     "dev": "deno serve -A --watch main.ts"
   },
   "imports": {
-    "@decelerate/cruiseh": "jsr:@decelerate/cruiseh@^0.2.0"
+    "@decelerate/cruiseh": "jsr:@decelerate/cruiseh@^0.3.0"
   }
 }

--- a/examples/deno-basic/main.ts
+++ b/examples/deno-basic/main.ts
@@ -1,4 +1,5 @@
 import { Router } from "@decelerate/cruiseh";
+import { getUrlParams } from "@decelerate/cruiseh/utils/getUrlParams";
 
 const app = new Router();
 
@@ -60,10 +61,14 @@ app.post("/hello", async (req) => {
 
 // get id params from url
 app.get("/hello/:id", (req, matchedRoute) => {
-  const routePattern = matchedRoute.exec(req.url);
-  const id = routePattern?.pathname.groups.id;
+  // If you don't want to use utils function you can do the same thing manually
+  //const routePattern = matchedRoute.exec(req.url);
+  //const params = routePattern?.pathname.groups;
 
-  const body = { id };
+  // For more secure way, you may need to try/catch your operations
+  const params = getUrlParams<{ id: string }>(matchedRoute, req.url);
+
+  const body = { id: params.id };
 
   return new Response(JSON.stringify(body), {
     status: 200,
@@ -76,7 +81,7 @@ app.get("/hello/:id", (req, matchedRoute) => {
 // from post request
 app.post("/hello/:id", async (req, matchedRoute) => {
   let body;
-  const id = matchedRoute.exec(req.url)?.pathname.groups.id;
+  const { id } = getUrlParams<{ id: string }>(matchedRoute, req.url);
 
   try {
     body = await req.json();

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -1,0 +1,117 @@
+import { assertEquals } from "jsr:@std/assert";
+import { Router } from "../router.ts";
+import { createFakeRequest } from "./utils.ts";
+
+Deno.test("Router should handle GET requests", async () => {
+  const router = new Router();
+
+  router.get("/hello", () => new Response("Hello world"));
+
+  const request = createFakeRequest("http://localhost/hello", "GET");
+  const response = await router.handler(request);
+
+  assertEquals(await response.text(), "Hello world");
+  assertEquals(response.status, 200);
+});
+
+Deno.test("Router should handle POST requests", async () => {
+  const router = new Router();
+
+  router.post("/hello", async (request) => {
+    const body = await request.json();
+    return new Response(JSON.stringify(body), {
+      headers: { "Content-Type": "application/json" },
+    });
+  });
+
+  const request = createFakeRequest(
+    "http://localhost/hello",
+    "POST",
+    {},
+    { message: "Hello world" },
+  );
+  const response = await router.handler(request);
+
+  assertEquals(await response.json(), { message: "Hello world" });
+  assertEquals(response.status, 200);
+});
+
+Deno.test("Router should handle PUT requests", async () => {
+  const router = new Router();
+
+  router.put("/hello", async (request) => {
+    const body = await request.json();
+    return new Response(JSON.stringify(body), {
+      headers: { "Content-Type": "application/json" },
+    });
+  });
+
+  const request = createFakeRequest(
+    "http://localhost/hello",
+    "PUT",
+    {},
+    { message: "Hello world" },
+  );
+  const response = await router.handler(request);
+
+  assertEquals(await response.json(), { message: "Hello world" });
+  assertEquals(response.status, 200);
+});
+
+Deno.test("Router should handle DELETE requests", async () => {
+  const router = new Router();
+
+  router.delete("/hello", (_) => {
+    return new Response("Delete confirmed");
+  });
+
+  const request = createFakeRequest(
+    "http://localhost/hello",
+    "DELETE",
+    {},
+  );
+  const response = await router.handler(request);
+
+  assertEquals(await response.text(), "Delete confirmed");
+  assertEquals(response.status, 200);
+});
+
+Deno.test("Router should fail to GET route", async () => {
+  const router = new Router();
+
+  router.get("/hello", () => new Response("Hello world"));
+
+  const request = createFakeRequest("http://localhost/hello", "POST");
+  const response = await router.handler(request);
+
+  assertEquals(response.status, 404);
+});
+
+Deno.test("Router should execute middleware", async () => {
+  const router = new Router();
+
+  let middlewareExecuted = false;
+  router.use((_, next) => {
+    middlewareExecuted = true;
+    return next();
+  });
+
+  router.get("/hello", () => new Response("Hello world"));
+
+  const request = createFakeRequest("http://localhost/hello", "GET");
+  const response = await router.handler(request);
+
+  assertEquals(middlewareExecuted, true);
+  assertEquals(await response.text(), "Hello world");
+  assertEquals(response.status, 200);
+});
+
+Deno.test("Router should return 404 for unknown routes", async () => {
+  const router = new Router();
+
+  const request = createFakeRequest("http://localhost/unknown", "GET");
+  const response = await router.handler(request);
+
+  assertEquals(response.status, 404);
+  assertEquals(await response.text(), "Not found");
+});

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,0 +1,26 @@
+/**
+ * Creates a fake Request object for testing purposes.
+ * @param {string} url - The URL of the request.
+ * @param {string} method - The HTTP method of the request.
+ * @param {Record<string, string>} [headers] - Optional headers for the request.
+ * @param {any} [body] - Optional body for the request.
+ * @returns {Request} - The fake Request object.
+ */
+export function createFakeRequest(
+  url: string,
+  method: string,
+  headers: Record<string, string> = {},
+  body: unknown = null,
+): Request {
+  const init: RequestInit = {
+    method,
+    headers: new Headers(headers),
+  };
+
+  if (body) {
+    init.body = JSON.stringify(body);
+    (init.headers as Headers).set("Content-Type", "application/json");
+  }
+
+  return new Request(url, init);
+}

--- a/utils/getUrlParams.test.ts
+++ b/utils/getUrlParams.test.ts
@@ -1,0 +1,24 @@
+import { assertEquals } from "jsr:@std/assert";
+import { getUrlParams } from "./getUrlParams.ts";
+
+Deno.test("getUrlParams should return id params from route", () => {
+  const pattern = new URLPattern({ pathname: "/hello/:id" });
+  const url = "http://localhost:3000/hello/123";
+  const params = getUrlParams<{ id: string }>(pattern, url);
+
+  assertEquals(params.id, "123");
+});
+
+Deno.test("getUrlParams should fail", () => {
+  let fail = false;
+
+  try {
+    const pattern = new URLPattern({ pathname: "/hello/:id" });
+    const url = "http://localhost:3000/hello/";
+    getUrlParams<{ id: string }>(pattern, url);
+  } catch (_err) {
+    fail = true;
+  }
+
+  assertEquals(fail, true);
+});

--- a/utils/getUrlParams.ts
+++ b/utils/getUrlParams.ts
@@ -1,0 +1,30 @@
+/**
+ * Type representing the response of a getUrlParams function.
+ */
+type GetUrlParamsResponseType<K> =
+  | K
+  | Record<string, string | undefined>;
+
+/**
+ * Extracts URL parameters from a matched URL pattern.
+ * @param {URLPattern} matchedUrl - The matched URL pattern.
+ * @param {string} url - The URL to extract parameters from.
+ * @returns {GetUrlParamsResponseType<K>} - The URL parameters.
+ * @template K
+ * @example
+ * ```typescript
+ * const pattern = new URLPattern({ pathname: "/hello/:id" });
+ * const url = "/hello/123";
+ * const params = getUrlParams<{ id: string }>(pattern, url);
+ * console.log(params); // { id: "123" }
+ * ```
+ */
+export function getUrlParams<K>(
+  matchedUrl: URLPattern,
+  url: string,
+): GetUrlParamsResponseType<K> {
+  const pattern = matchedUrl.exec(url);
+  const params = pattern?.pathname.groups;
+  if (!params) throw new Error("No url params found.");
+  return params;
+}


### PR DESCRIPTION
This pull request includes various updates and improvements to the `Cruiseh` project. The most important changes involve renaming the GitHub Actions workflow file, updating the `README.md`, adding new utility functions, and enhancing the test suite.

### Workflow and Configuration Updates:
* Renamed `.github/workflows/test.yml` to `.github/workflows/tests.yml` and updated job names and steps accordingly. [[1]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL9-R9) [[2]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL21-R23)

### Documentation Updates:
* Updated the workflow badge URL in `README.md` to reflect the renamed workflow file.
* Added an example import statement for `getUrlParams` in the `README.md` usage example.
* Updated the example code to use the `getUrlParams` utility function for extracting URL parameters.

### Version and Dependency Updates:
* Bumped the version in `deno.json` from `0.2.0` to `0.3.0` and added `utils.ts` to the list of exported files. [[1]](diffhunk://#diff-54337bcff4b919f6b8b4e0b0e51d06fd9124562fde88899be726c24b7e354b7cL3-R3) [[2]](diffhunk://#diff-54337bcff4b919f6b8b4e0b0e51d06fd9124562fde88899be726c24b7e354b7cL18-R23)
* Updated the version of `@decelerate/cruiseh` in `examples/deno-basic/deno.json` to `^0.3.0`.

### Code Enhancements:
* Added `getUrlParams` utility function to extract URL parameters more securely.
* Updated example code in `examples/deno-basic/main.ts` to use the `getUrlParams` utility function. [[1]](diffhunk://#diff-f4f39e2a2ed96000bdbc94429843f95b04ba9cb093285cbc05b16111f15e0665R2) [[2]](diffhunk://#diff-f4f39e2a2ed96000bdbc94429843f95b04ba9cb093285cbc05b16111f15e0665L63-R71) [[3]](diffhunk://#diff-f4f39e2a2ed96000bdbc94429843f95b04ba9cb093285cbc05b16111f15e0665L79-R84)

### Test Suite Enhancements:
* Added comprehensive tests for various HTTP methods (GET, POST, PUT, DELETE) in `tests/router.test.ts`.
* Added a utility function `createFakeRequest` for creating fake request objects in tests.
* Added tests for the `getUrlParams` function to ensure it correctly extracts URL parameters.