### PR TITLE
feat(utils): add getUrlParams function

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,6 @@ jobs:
       - name: Fmt check
         run: deno fmt --check
       - name: Types check
-        run: deno check .
+        run: deno check router.ts types.ts utils/
       - name: Testing
-        run: deno test tests/
+        run: deno test .

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Here's an example of how to use the Router class with deno serve :
 ```ts
 // server.ts
 import { Router } from '@decelerate/cruiseh';
+import { getUrlParams } from "@decelerate/cruiseh/utils/getUrlParams";
 
 const app = new Router();
 
@@ -54,9 +55,14 @@ app.post("/hello", async (req) => {
 
 // With params
 app.get("/hello/:id", (_req, matchedRoute) => {
-  const routePattern = matchedRoute.exec(req.url)
-  const id = routePattern?.pathname.groups.id;
-  const body = { id };
+  // If you don't want to use utils function you can do the same thing manually
+  //const routePattern = matchedRoute.exec(req.url);
+  //const params = routePattern?.pathname.groups;
+
+  // For more secure way, you may need to try/catch your operations
+  const params = getUrlParams<{ id: string }>(matchedRoute, req.url);
+
+  const body = { id: params.id };
 
   return new Response(JSON.stringify(body), {
     status: 200,

--- a/deno.json
+++ b/deno.json
@@ -15,16 +15,12 @@
       "deno.json",
       "index.ts",
       "router.ts",
-      "types.ts"
+      "types.ts",
+      "utils.ts"
     ]
   },
   "tasks": {
-    "doc:gen": "deno doc --html --name=\"Cruiseh API\" ./index.ts",
-    "doc:dev": "deno run -A docs-dev-server.ts",
-    "doc:lint": "deno doc --lint index.ts",
-    "fmt": "deno fmt",
-    "fmt:check": "deno fmt --check",
-    "check": "deno check ."
+    "check": "deno check router.ts types.ts utils/"
   },
   "fmt": {
     "exclude": [

--- a/examples/deno-basic/main.ts
+++ b/examples/deno-basic/main.ts
@@ -1,4 +1,5 @@
 import { Router } from "@decelerate/cruiseh";
+import { getUrlParams } from "@decelerate/cruiseh/utils/getUrlParams";
 
 const app = new Router();
 
@@ -60,10 +61,14 @@ app.post("/hello", async (req) => {
 
 // get id params from url
 app.get("/hello/:id", (req, matchedRoute) => {
-  const routePattern = matchedRoute.exec(req.url);
-  const id = routePattern?.pathname.groups.id;
+  // If you don't want to use utils function you can do the same thing manually
+  //const routePattern = matchedRoute.exec(req.url);
+  //const params = routePattern?.pathname.groups;
 
-  const body = { id };
+  // For more secure way, you may need to try/catch your operations
+  const params = getUrlParams<{ id: string }>(matchedRoute, req.url);
+
+  const body = { id: params.id };
 
   return new Response(JSON.stringify(body), {
     status: 200,
@@ -76,7 +81,7 @@ app.get("/hello/:id", (req, matchedRoute) => {
 // from post request
 app.post("/hello/:id", async (req, matchedRoute) => {
   let body;
-  const id = matchedRoute.exec(req.url)?.pathname.groups.id;
+  const { id } = getUrlParams<{ id: string }>(matchedRoute, req.url);
 
   try {
     body = await req.json();

--- a/utils/getUrlParams.test.ts
+++ b/utils/getUrlParams.test.ts
@@ -1,0 +1,24 @@
+import { assertEquals } from "jsr:@std/assert";
+import { getUrlParams } from "./getUrlParams.ts";
+
+Deno.test("getUrlParams should return id params from route", () => {
+  const pattern = new URLPattern({ pathname: "/hello/:id" });
+  const url = "http://localhost:3000/hello/123";
+  const params = getUrlParams<{ id: string }>(pattern, url);
+
+  assertEquals(params.id, "123");
+});
+
+Deno.test("getUrlParams should fail", () => {
+  let fail = false;
+
+  try {
+    const pattern = new URLPattern({ pathname: "/hello/:id" });
+    const url = "http://localhost:3000/hello/";
+    getUrlParams<{ id: string }>(pattern, url);
+  } catch (_err) {
+    fail = true;
+  }
+
+  assertEquals(fail, true);
+});

--- a/utils/getUrlParams.ts
+++ b/utils/getUrlParams.ts
@@ -1,0 +1,30 @@
+/**
+ * Type representing the response of a getUrlParams function.
+ */
+type GetUrlParamsResponseType<K> =
+  | K
+  | Record<string, string | undefined>;
+
+/**
+ * Extracts URL parameters from a matched URL pattern.
+ * @param {URLPattern} matchedUrl - The matched URL pattern.
+ * @param {string} url - The URL to extract parameters from.
+ * @returns {GetUrlParamsResponseType<K>} - The URL parameters.
+ * @template K
+ * @example
+ * ```typescript
+ * const pattern = new URLPattern({ pathname: "/hello/:id" });
+ * const url = "/hello/123";
+ * const params = getUrlParams<{ id: string }>(pattern, url);
+ * console.log(params); // { id: "123" }
+ * ```
+ */
+export function getUrlParams<K>(
+  matchedUrl: URLPattern,
+  url: string,
+): GetUrlParamsResponseType<K> {
+  const pattern = matchedUrl.exec(url);
+  const params = pattern?.pathname.groups;
+  if (!params) throw new Error("No url params found.");
+  return params;
+}


### PR DESCRIPTION
This pull request includes several updates to improve the functionality and documentation of the `@decelerate/cruiseh` package. The changes primarily focus on enhancing the URL parameter extraction and updating the testing and build configurations.

### Enhancements to URL parameter extraction:
* [`utils/getUrlParams.ts`](diffhunk://#diff-bd97e26bd164aca1bbbcf751d9a88b6a549f1eca625a3a226d25799888c7404aR1-R30): Added a new utility function `getUrlParams` to extract URL parameters from a matched URL pattern. This function includes type definitions and error handling.
* [`utils/getUrlParams.test.ts`](diffhunk://#diff-217bfed966d28d72a63315c6849f0d319332fc0f2a1c208eb6344353655d494dR1-R24): Added tests for the `getUrlParams` function to ensure it correctly extracts parameters and handles errors.

### Documentation updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R38): Updated the example usage of the `Router` class to include the `getUrlParams` utility function for extracting URL parameters. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R38) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L57-R65)

### Codebase updates:
* [`.github/workflows/tests.yml`](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL21-R23): Modified the test and type check commands to include specific files and directories.
* [`deno.json`](diffhunk://#diff-54337bcff4b919f6b8b4e0b0e51d06fd9124562fde88899be726c24b7e354b7cL18-R23): Updated the `check` task to include specific files and added `utils.ts` to the `files` array.

### Example updates:
* [`examples/deno-basic/main.ts`](diffhunk://#diff-f4f39e2a2ed96000bdbc94429843f95b04ba9cb093285cbc05b16111f15e0665R2): Updated the example to use the `getUrlParams` function for extracting URL parameters. [[1]](diffhunk://#diff-f4f39e2a2ed96000bdbc94429843f95b04ba9cb093285cbc05b16111f15e0665R2) [[2]](diffhunk://#diff-f4f39e2a2ed96000bdbc94429843f95b04ba9cb093285cbc05b16111f15e0665L63-R71) [[3]](diffhunk://#diff-f4f39e2a2ed96000bdbc94429843f95b04ba9cb093285cbc05b16111f15e0665L79-R84)